### PR TITLE
Add try-except around (attempted) use of forkserver

### DIFF
--- a/rul_baseline.py
+++ b/rul_baseline.py
@@ -153,6 +153,11 @@ def RMSE(rul, pred_rul):
 if __name__ == "__main__":
     rep = sys.argv[1]
     n_jobs = multiprocessing.cpu_count()
+    try:
+        if n_jobs > 1:
+            multiprocessing.set_start_method('forkserver')
+    except ValueError:
+        pass  # forkserver apparently not supported on this platform
 
     output_file = 'Baselines_run-' + str(rep)
     if not os.path.isdir(output_file):

--- a/rul_pipeline.py
+++ b/rul_pipeline.py
@@ -217,6 +217,11 @@ def RMSE(rul, pred_rul):
 if __name__ == "__main__":
     rep = sys.argv[1]
     n_jobs = multiprocessing.cpu_count()
+    try:
+        if n_jobs > 1:
+            multiprocessing.set_start_method('forkserver')
+    except ValueError:
+        pass  # forkserver apparently not supported on this platform
 
     output_file = 'TIM_RUN-local-' + str(rep)
     if not os.path.exists(output_file):


### PR DESCRIPTION
This undoes the earlier removal of set_start_method('forkserver'), which
caused issues on platforms that don't support this, such as Windows.

Since 'forkserver' as startmethod does seem to have speed advantages, it
is better for performance to try to enable it if available.